### PR TITLE
shm_size and fix for 3.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.5"
 
 services:
   webserver:


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/51517189/docker-compose-error-build-contains-unsupported-option-shm-size